### PR TITLE
Swap implementation helper to being unnaccessible to outside classes

### DIFF
--- a/src/main/java/lint/BaseJSONAnalyzer.java
+++ b/src/main/java/lint/BaseJSONAnalyzer.java
@@ -1,4 +1,4 @@
-package helpers;
+package lint;
 
 import objects.JSONArray;
 import objects.JSONObject;
@@ -8,9 +8,9 @@ import objects.WrappedPrimitive;
 import java.util.Arrays;
 import java.util.List;
 
-public class ImplementationHelper {
+public abstract class BaseJSONAnalyzer {
 
-    public static boolean hasKeyAndValueEqualTo(JSONObject jsonObject, String key, Object toCheck) {
+    protected boolean hasKeyAndValueEqualTo(JSONObject jsonObject, String key, Object toCheck) {
         if (jsonObject == null) {
             return false;
         }
@@ -20,7 +20,7 @@ public class ImplementationHelper {
                 || (desiredObject != null && desiredObject.equals(toCheck));
     }
 
-    public static boolean hasIndexAndValueEqualTo(JSONArray jsonArray, int index, Object toCheck) {
+    protected boolean hasIndexAndValueEqualTo(JSONArray jsonArray, int index, Object toCheck) {
         if (jsonArray == null) {
             return false;
         }
@@ -35,7 +35,7 @@ public class ImplementationHelper {
                 || desiredObject != null && desiredObject.equals(toCheck);
     }
 
-    private static Object safeGet(JSONObject jsonObject, String key) {
+    private Object safeGet(JSONObject jsonObject, String key) {
         if (jsonObject == null || key == null) {
             return null;
         }
@@ -47,7 +47,7 @@ public class ImplementationHelper {
         }
     }
 
-    public static WrappedPrimitive safeGetWrappedPrimitive(JSONObject jsonObject, String key) {
+    protected WrappedPrimitive safeGetWrappedPrimitive(JSONObject jsonObject, String key) {
         Object fromObject = safeGet(jsonObject, key);
         if (fromObject == null || !(fromObject instanceof WrappedPrimitive)) {
             return null;
@@ -55,7 +55,7 @@ public class ImplementationHelper {
         return (WrappedPrimitive) fromObject;
     }
 
-    public static JSONObject safeGetJSONObject(JSONObject jsonObject, String key) {
+    protected  JSONObject safeGetJSONObject(JSONObject jsonObject, String key) {
         Object fromObject = safeGet(jsonObject, key);
         if (fromObject == null || !(fromObject instanceof JSONObject)) {
             return null;
@@ -63,7 +63,7 @@ public class ImplementationHelper {
         return (JSONObject) fromObject;
     }
 
-    public static JSONArray safeGetJSONArray(JSONObject jsonObject, String key) {
+    protected JSONArray safeGetJSONArray(JSONObject jsonObject, String key) {
         Object fromObject = safeGet(jsonObject, key);
         if (fromObject == null || !(fromObject instanceof JSONArray)) {
             return null;
@@ -71,7 +71,7 @@ public class ImplementationHelper {
         return (JSONArray) fromObject;
     }
 
-    private static Object safeGetIndex(JSONArray array, int index) {
+    private Object safeGetIndex(JSONArray array, int index) {
         if (array == null || index < 0) {
             return null;
         }
@@ -84,7 +84,7 @@ public class ImplementationHelper {
         return arrayList.get(index);
     }
 
-    public static WrappedPrimitive safeGetWrappedPrimitive(JSONArray array, int index) {
+    protected WrappedPrimitive safeGetWrappedPrimitive(JSONArray array, int index) {
         Object fromArray = safeGetIndex(array, index);
         if (fromArray == null || !(fromArray instanceof WrappedPrimitive)) {
             return  null;
@@ -92,7 +92,7 @@ public class ImplementationHelper {
         return (WrappedPrimitive) fromArray;
     }
 
-    public static JSONObject safeGetJSONObject(JSONArray array, int index) {
+    protected JSONObject safeGetJSONObject(JSONArray array, int index) {
         Object fromArray = safeGetIndex(array, index);
         if (fromArray == null || !(fromArray instanceof JSONObject)) {
             return  null;
@@ -100,7 +100,7 @@ public class ImplementationHelper {
         return (JSONObject) fromArray;
     }
 
-    public static JSONArray safeGetJSONArray(JSONArray array, int index) {
+    protected JSONArray safeGetJSONArray(JSONArray array, int index) {
         Object fromArray = safeGetIndex(array, index);
         if (fromArray == null || !(fromArray instanceof JSONArray)) {
             return  null;
@@ -108,17 +108,17 @@ public class ImplementationHelper {
         return (JSONArray) fromArray;
     }
 
-    public static <T> boolean isEqualTo(WrappedPrimitive<T> wrappedPrimitive, T toCheck) {
+    protected <T> boolean isEqualTo(WrappedPrimitive<T> wrappedPrimitive, T toCheck) {
         return wrappedPrimitive.equals(toCheck);
     }
 
-    public static boolean isOriginatingKeyEqualTo(WrappedObject object, String toCheck) {
+    protected boolean isOriginatingKeyEqualTo(WrappedObject object, String toCheck) {
         return object != null
                 && ((object.getOriginatingKey() == null && toCheck == null)
                 || object.getOriginatingKey() != null && object.getOriginatingKey().equals(toCheck));
     }
 
-    public static <T> boolean isType(Object object, Class<T> clazz) {
+    protected <T> boolean isType(Object object, Class<T> clazz) {
         if (object instanceof WrappedPrimitive) {
             if (clazz.isInstance(object)) {
                 return clazz.isInstance(object);
@@ -129,12 +129,12 @@ public class ImplementationHelper {
         return clazz.isInstance(object);
     }
 
-    public static <T> boolean isParentOfType(WrappedObject object, Class<T> clazz) {
+    protected <T> boolean isParentOfType(WrappedObject object, Class<T> clazz) {
         return (object.getParentObject() == null && clazz == null)
                 || isType(object.getParentObject(), clazz);
     }
 
-    public static boolean reduceBooleans(Boolean... booleans) {
+    protected boolean reduceBooleans(Boolean... booleans) {
         return Arrays.stream(booleans).filter(b -> !b).count() == 0;
     }
 }

--- a/src/main/java/lint/LintImplementation.java
+++ b/src/main/java/lint/LintImplementation.java
@@ -1,69 +1,8 @@
 package lint;
 
-import helpers.ImplementationHelper;
-import objects.JSONArray;
-import objects.JSONObject;
-import objects.WrappedObject;
-import objects.WrappedPrimitive;
-
-import java.util.Arrays;
-import java.util.List;
-
-public abstract class LintImplementation<T> {
+public abstract class LintImplementation<T> extends BaseJSONAnalyzer {
 
     public abstract Class<T> getClazz();
 
     public abstract boolean shouldReport(T t);
-
-    protected boolean hasKeyAndValueEqualTo(JSONObject jsonObject, String key, Object toCheck) {
-        return ImplementationHelper.hasKeyAndValueEqualTo(jsonObject, key, toCheck);
-    }
-
-    protected boolean hasIndexAndValueEqualTo(JSONArray jsonArray, int index, Object toCheck) {
-        return ImplementationHelper.hasIndexAndValueEqualTo(jsonArray, index, toCheck);
-    }
-
-    public static WrappedPrimitive safeGetWrappedPrimitive(JSONObject jsonObject, String key) {
-        return ImplementationHelper.safeGetWrappedPrimitive(jsonObject, key);
-    }
-
-    public static JSONObject safeGetJSONObject(JSONObject jsonObject, String key) {
-        return ImplementationHelper.safeGetJSONObject(jsonObject, key);
-    }
-
-    public static JSONArray safeGetJSONArray(JSONObject jsonObject, String key) {
-        return ImplementationHelper.safeGetJSONArray(jsonObject, key);
-    }
-
-    public static WrappedPrimitive safeGetWrappedPrimitive(JSONArray jsonArray, int index) {
-        return ImplementationHelper.safeGetWrappedPrimitive(jsonArray, index);
-    }
-
-    public static JSONObject safeGetJSONObject(JSONArray jsonArray, int index) {
-        return ImplementationHelper.safeGetJSONObject(jsonArray, index);
-    }
-
-    public static JSONArray safeGetJSONArray(JSONArray jsonArray, int index) {
-        return ImplementationHelper.safeGetJSONArray(jsonArray, index);
-    }
-
-    protected  <E> boolean isEqualTo(WrappedPrimitive<E> wrappedPrimitive, E toCheck) {
-        return ImplementationHelper.isEqualTo(wrappedPrimitive, toCheck);
-    }
-
-    protected boolean isOriginatingKeyEqualTo(WrappedObject object, String toCheck) {
-        return ImplementationHelper.isOriginatingKeyEqualTo(object, toCheck);
-    }
-
-    protected <E> boolean isType(Object object, Class<E> clazz) {
-        return ImplementationHelper.isType(object, clazz);
-    }
-
-    protected <E> boolean isParentOfType(WrappedObject object, Class<E> clazz) {
-        return ImplementationHelper.isParentOfType(object, clazz);
-    }
-
-    protected boolean reduceBooleans(Boolean ...booleans) {
-        return ImplementationHelper.reduceBooleans(booleans);
-    }
 }

--- a/src/main/java/lint/LintRule.java
+++ b/src/main/java/lint/LintRule.java
@@ -30,6 +30,10 @@ public class LintRule {
     @SuppressWarnings("unchecked")
     public void lint(JSONFile jsonFile) {
         List<?> filteredList = FilterMapper.filter(jsonFile, implementation);
+        if (filteredList == null) {
+            return;
+        }
+
         for (Object element : filteredList) {
             if (implementation.shouldReport(element)) {
                 System.out.println("Error in " + jsonFile.getFilePath());

--- a/src/test/java/learn/MainTest.java
+++ b/src/test/java/learn/MainTest.java
@@ -1,7 +1,5 @@
 package learn;
 
-import filters.Filters;
-import helpers.ImplementationHelper;
 import lint.LintImplementation;
 import lint.LintLevel;
 import lint.LintRegister;
@@ -31,29 +29,6 @@ public class MainTest {
 
     @Test
     public void testJson() throws Exception {
-        Filters filter = new Filters();
-//        log.info(filter.filterToObjects(jsonFile).toString());
-//        log.info(filter.filterToArrays(jsonFile).toString());
-//        log.info(filter.filterToStrings(jsonFile).toString());
-
-//        ArrayList<WrappedPrimitive<String>> wrappedStrings = filter.filterToStrings(jsonFile);
-//        wrappedStrings.forEach(e-> log.info(e.getOriginatingKey() + "\t" + e.toString()));
-
-//        ArrayList<JSONObject> objects = filter.filterToObjects(jsonFile);
-//        objects.forEach(e -> log.info(e.getOriginatingKey()));
-//
-//        objects.forEach(jsonObject -> {
-//            if (jsonObject.getOriginatingKey().equals("fields")
-//                    && jsonObject.getParentObject() instanceof JSONArray
-//                    && jsonObject.get("type").equals("boolean")
-//                    && ((String) jsonObject.get("name")).startsWith("has")) {
-//                log.info("CAUGHT");
-//            }
-//        });
-
-//        jsonFile.getObject().toMap().entrySet().forEach(entry ->
-//            log.info(entry.getKey() + "\t" + entry.getValue()));
-
         LintImplementation<JSONObject> lintImplementation = new LintImplementation<JSONObject>() {
 
             @Override


### PR DESCRIPTION
Swap ImplementationHelpers to being an abstract class.  Avoid exposing accessors when outside of a lint implementation